### PR TITLE
Fix/hce character cloning

### DIFF
--- a/app/src/main/java/com/github/nacabaro/vbhelper/screens/scanScreen/ScanScreen.kt
+++ b/app/src/main/java/com/github/nacabaro/vbhelper/screens/scanScreen/ScanScreen.kt
@@ -44,14 +44,8 @@ fun ScanScreen(
 
     val context = LocalContext.current
 
-    LaunchedEffect(storageRepository) {
+    LaunchedEffect(characterId) {
         withContext(Dispatchers.IO) {
-            /*
-            First check if there is a character sent through the navigation system
-            If there is not, that means we got here through the home screen nfc button
-            If we got here through the home screen, it does not hurt to check if there is
-            an active character.
-             */
             if (characterId != null && nfcCharacter == null) {
                 nfcCharacter = scanScreenController.characterToNfc(characterId)
             }

--- a/app/src/main/java/com/github/nacabaro/vbhelper/screens/scanScreen/ScanScreenControllerImpl.kt
+++ b/app/src/main/java/com/github/nacabaro/vbhelper/screens/scanScreen/ScanScreenControllerImpl.kt
@@ -231,7 +231,9 @@ class ScanScreenControllerImpl(
                     val proto = VitalWearCharacterExporter(componentActivity, database).buildCharacterProto(characterId)
                     val client = VitalWearHceReaderClient(isoDep)
                     client.sendCharacterToWatch(proto)
-                    Log.i("NFC_WRITE", "Character sent to VitalWear via HCE")
+                    database.userCharacterDao().deleteCharacterById(characterId)
+                    pendingExportCharacterId = null
+                    Log.i("NFC_WRITE", "Character sent to VitalWear and deleted from app (id=$characterId)")
                     componentActivity.runOnUiThread {
                         Toast.makeText(componentActivity, componentActivity.getString(R.string.scan_sent_character_success), Toast.LENGTH_SHORT).show()
                     }


### PR DESCRIPTION
**Fix character cloning when sending to VitalWear watch via HCE**

When transferring a character from VBHelper to the VitalWear watch using NFC/HCE, the character was remaining in the app after the transfer, allowing it to be duplicated indefinitely.

- **Delete after successful transfer:** The character is now removed from the database immediately after `sendCharacterToWatch` succeeds. Since HCE transfers are atomic (unlike physical bracelets which require two separate NFC interactions), the deletion happens in the check card phase once the transfer is confirmed.

- **Fix LaunchedEffect key in ScanScreen:** When opening the scan screen from the home button, the character ID is loaded asynchronously from the active character. The previous effect key never re-triggered when the ID became available, so the character setup was skipped and the deletion logic was unreachable from that flow.