### PR TITLE
Fix special missions crash and NaN% stat display

### DIFF
--- a/app/src/main/java/com/github/nacabaro/vbhelper/screens/homeScreens/HomeScreenControllerImpl.kt
+++ b/app/src/main/java/com/github/nacabaro/vbhelper/screens/homeScreens/HomeScreenControllerImpl.kt
@@ -45,11 +45,12 @@ class HomeScreenControllerImpl(
                 .clearSpecialMission(missionId)
 
             if (missionStatus.status == SpecialMission.Status.COMPLETED) {
-                val randomItem = database
-                    .itemDao()
-                    .getAllItems()
-                    .first()
-                    .random()
+                val allItems = database.itemDao().getAllItems().first()
+                if (allItems.isEmpty()) {
+                    onCleared(null, null)
+                    return@launch
+                }
+                val randomItem = allItems.random()
 
                 val randomItemAmount = (Random.nextFloat() * 5).roundToInt()
 

--- a/app/src/main/java/com/github/nacabaro/vbhelper/screens/homeScreens/screens/VBDiMHomeScreen.kt
+++ b/app/src/main/java/com/github/nacabaro/vbhelper/screens/homeScreens/screens/VBDiMHomeScreen.kt
@@ -142,7 +142,7 @@ fun VBDiMHomeScreen(
             ItemDisplay(
                 icon = R.drawable.baseline_swords_24,
                 textValue = when {
-                    activeMon.totalBattlesLost == 0 -> "0.00 %"
+                    activeMon.currentPhaseBattlesWon + activeMon.currentPhaseBattlesLost == 0 -> "0.00 %"
                     else -> {
                         val battleWinPercentage =
                             activeMon.currentPhaseBattlesWon.toFloat() / (activeMon.currentPhaseBattlesWon + activeMon.currentPhaseBattlesLost).toFloat()
@@ -150,7 +150,7 @@ fun VBDiMHomeScreen(
                             Locale.getDefault(),
                             "%.2f",
                             battleWinPercentage * 100
-                        ) + " %" // Specify locale
+                        ) + " %"
                     }
                 },
                 definition = stringResource(R.string.home_vbdim_current_phase_win),
@@ -193,9 +193,9 @@ fun VBDiMHomeScreen(
                     onClickMission = { missionId ->
                         selectedSpecialMissionId = missionId
                     },
-                    onClickCollect = {
+                    onClickCollect = { missionId ->
                         homeScreenController
-                            .clearSpecialMission(selectedSpecialMissionId, onClickCollect)
+                            .clearSpecialMission(missionId, onClickCollect)
                     }
                 )
             }


### PR DESCRIPTION
- Fix crash when tapping a completed special mission: onClickCollect was ignoring the missionId passed by SpecialMissionsEntry and using selectedSpecialMissionId (-1 by default), causing Room to query id=-1 on a non-nullable Flow which throws when no row exists.
- Fix NaN% in current phase win rate: the guard was checking totalBattlesLost==0 but dividing by currentPhaseBattles, producing 0/0=NaN when total>0 but current phase has no battles yet.
- Guard against empty items list in clearSpecialMission to avoid NoSuchElementException from random() on an empty collection.