### PR TITLE
Fix/vitalwear import device type

### DIFF
--- a/app/src/main/java/com/github/nacabaro/vbhelper/daos/CardDao.kt
+++ b/app/src/main/java/com/github/nacabaro/vbhelper/daos/CardDao.kt
@@ -34,7 +34,7 @@ interface CardDao {
         WHERE uc.id = :id
     """
     )
-    fun getCardByCharacterId(id: Long): Flow<Card>
+    fun getCardByCharacterId(id: Long): Flow<Card?>
 
     @Query(
         """

--- a/app/src/main/java/com/github/nacabaro/vbhelper/daos/UserCharacterDao.kt
+++ b/app/src/main/java/com/github/nacabaro/vbhelper/daos/UserCharacterDao.kt
@@ -167,6 +167,9 @@ interface UserCharacterDao {
     @Query("DELETE FROM UserCharacter WHERE id = :id")
     fun deleteCharacterById(id: Long)
 
+    @Query("SELECT EXISTS(SELECT 1 FROM UserCharacter WHERE id = :id)")
+    suspend fun characterExists(id: Long): Boolean
+
     @Query("UPDATE UserCharacter SET isActive = 0 WHERE isActive = 1")
     fun clearActiveCharacter()
 

--- a/app/src/main/java/com/github/nacabaro/vbhelper/screens/homeScreens/HomeScreen.kt
+++ b/app/src/main/java/com/github/nacabaro/vbhelper/screens/homeScreens/HomeScreen.kt
@@ -128,7 +128,7 @@ fun HomeScreen(
             )
         }
     ) { contentPadding ->
-        if (activeMon == null || (beData == null && vbData == null) || cardIconData == null || transformationHistory.isEmpty()) {
+        if (activeMon == null || (beData == null && vbData == null) || cardIconData == null) {
             Column (
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.Center,

--- a/app/src/main/java/com/github/nacabaro/vbhelper/screens/itemsScreen/ItemsScreenControllerImpl.kt
+++ b/app/src/main/java/com/github/nacabaro/vbhelper/screens/itemsScreen/ItemsScreenControllerImpl.kt
@@ -180,6 +180,10 @@ class ItemsScreenControllerImpl (
             .getSpecialMissions(characterId)
             .first()
 
+        if (availableSpecialMissions.size <= specialMissionSlot) {
+            return
+        }
+
         var newSpecialMission = availableSpecialMissions[specialMissionSlot]
         newSpecialMission = SpecialMissions(
             id = newSpecialMission.id,

--- a/app/src/main/java/com/github/nacabaro/vbhelper/screens/scanScreen/ScanScreen.kt
+++ b/app/src/main/java/com/github/nacabaro/vbhelper/screens/scanScreen/ScanScreen.kt
@@ -139,6 +139,7 @@ fun ScanScreenPreview() {
             override fun cancelRead() {}
             override fun characterFromNfc(nfcCharacter: NfcCharacter, onMultipleCards: (List<Card>, NfcCharacter) -> Unit): String { return "" }
             override suspend fun characterToNfc(characterId: Long): NfcCharacter? { return null }
+            override suspend fun characterExists(characterId: Long): Boolean { return true }
         },
         characterId = null,
         launchedFromHomeScreen = false

--- a/app/src/main/java/com/github/nacabaro/vbhelper/screens/scanScreen/ScanScreenController.kt
+++ b/app/src/main/java/com/github/nacabaro/vbhelper/screens/scanScreen/ScanScreenController.kt
@@ -24,4 +24,6 @@ interface ScanScreenController {
         onMultipleCards: (List<Card>, NfcCharacter) -> Unit
     ): String
     suspend fun characterToNfc(characterId: Long): NfcCharacter?
+
+    suspend fun characterExists(characterId: Long): Boolean
 }

--- a/app/src/main/java/com/github/nacabaro/vbhelper/screens/scanScreen/ScanScreenControllerImpl.kt
+++ b/app/src/main/java/com/github/nacabaro/vbhelper/screens/scanScreen/ScanScreenControllerImpl.kt
@@ -76,12 +76,21 @@ class ScanScreenControllerImpl(
             hceHandler = { isoDep ->
                 try {
                     val client = VitalWearHceReaderClient(isoDep)
-                    val character = client.receiveCharacterFromWatch()
                     val importer = VitalWearCharacterImporter(database)
-                    val result = importer.importCharacter(character)
-                    Log.i("NFC_READ", "VitalWear HCE import: ${result.message}")
+                    // Read the character first and only COMMIT (which makes the watch
+                    // drop its copy) if the import actually succeeds. Otherwise the
+                    // character stays on the watch and nothing is lost.
+                    var importResult: VitalWearCharacterImporter.ImportResult? = null
+                    val committed = client.moveCharacterFromWatch { character ->
+                        val result = importer.importCharacter(character)
+                        importResult = result
+                        result.success
+                    }
+                    val message = importResult?.message
+                        ?: componentActivity.getString(R.string.scan_error_generic)
+                    Log.i("NFC_READ", "VitalWear HCE import committed=$committed: $message")
                     componentActivity.runOnUiThread {
-                        Toast.makeText(componentActivity, result.message, Toast.LENGTH_SHORT).show()
+                        Toast.makeText(componentActivity, message, Toast.LENGTH_LONG).show()
                     }
                 } catch (e: Exception) {
                     Log.e("NFC_READ", "Error reading character from VitalWear HCE", e)
@@ -190,6 +199,10 @@ class ScanScreenControllerImpl(
                         Log.d("SendCharacter", "BENfcCharacter")
                         tagCommunicator.sendCharacter(nfcCharacter)
                     }
+                    // Physical bracelet write succeeded: remove the local copy here so the
+                    // WritingScreen no longer owns deletion (single source of truth).
+                    pendingExportCharacterId?.let { database.userCharacterDao().deleteCharacterById(it) }
+                    pendingExportCharacterId = null
                     onComplete.invoke()
                     componentActivity.getString(R.string.scan_sent_character_success)
                 } catch (e: Throwable) {
@@ -198,7 +211,8 @@ class ScanScreenControllerImpl(
                 }
             },
             hceHandler = { _ ->
-                // Character was already sent in onClickCheckCard's HCE handler.
+                // HCE: the character was already sent AND deleted (only if confirmed)
+                // in onClickCheckCard's HCE handler. Nothing to do here.
                 onComplete()
             }
         )
@@ -230,6 +244,11 @@ class ScanScreenControllerImpl(
                 try {
                     val proto = VitalWearCharacterExporter(componentActivity, database).buildCharacterProto(characterId)
                     val client = VitalWearHceReaderClient(isoDep)
+                    // The watch firmware only implements NEGOTIATE/WRITE_CHUNK/COMMIT (no
+                    // INS_STATUS), so we send and rely on COMMIT returning SW_OK as the signal
+                    // that the watch received the full payload. sendCharacterToWatch throws if
+                    // any APDU (including COMMIT) fails, so reaching the next line means the
+                    // transfer was accepted by the watch — only then do we delete the local copy.
                     client.sendCharacterToWatch(proto)
                     database.userCharacterDao().deleteCharacterById(characterId)
                     pendingExportCharacterId = null
@@ -271,6 +290,10 @@ class ScanScreenControllerImpl(
         val character = nfcGenerator.characterToNfc(characterId)
         Log.d("CharacterType", character.toString())
         return character
+    }
+
+    override suspend fun characterExists(characterId: Long): Boolean {
+        return database.userCharacterDao().characterExists(characterId)
     }
 
     override fun flushCharacter(cardId: Long) {

--- a/app/src/main/java/com/github/nacabaro/vbhelper/screens/scanScreen/converters/ToNfcConverter.kt
+++ b/app/src/main/java/com/github/nacabaro/vbhelper/screens/scanScreen/converters/ToNfcConverter.kt
@@ -104,7 +104,7 @@ class ToNfcConverter(
             0u
         }
 
-        appReserved[0] = cardData.id.toUShort()
+        appReserved[0] = cardData?.id?.toUShort() ?: 0u
 
         return appReserved
     }

--- a/app/src/main/java/com/github/nacabaro/vbhelper/screens/scanScreen/screens/WriteCardScreen.kt
+++ b/app/src/main/java/com/github/nacabaro/vbhelper/screens/scanScreen/screens/WriteCardScreen.kt
@@ -43,16 +43,7 @@ fun WriteCardScreen(
     val application = LocalContext.current.applicationContext as VBHelper
     val database = application.container.db
     val scanRepository = ScanRepository(database)
-    val cardDetails by scanRepository.getCardDetails(characterId).collectAsState(Card(
-        id = 0,
-        cardId = 0,
-        name = "",
-        logo = byteArrayOf(),
-        logoHeight = 0,
-        logoWidth = 0,
-        stageCount = 0,
-        isBEm = false
-    ))
+    val cardDetails by scanRepository.getCardDetails(characterId).collectAsState(null)
 
     Scaffold(
         topBar = {
@@ -77,11 +68,11 @@ fun WriteCardScreen(
                 Row (
                     modifier = Modifier.padding(16.dp),
                 ){
-                    if (cardDetails.logoHeight > 0 && cardDetails.logoWidth > 0) {
+                    if (cardDetails != null && cardDetails!!.logoHeight > 0 && cardDetails!!.logoWidth > 0) {
                         val charaBitmapData = BitmapData(
-                            bitmap = cardDetails.logo,
-                            width = cardDetails.logoWidth,
-                            height = cardDetails.logoHeight
+                            bitmap = cardDetails!!.logo,
+                            width = cardDetails!!.logoWidth,
+                            height = cardDetails!!.logoHeight
                         )
                         val charaImageBitmapData = charaBitmapData.getImageBitmap(
                             context = LocalContext.current,
@@ -123,7 +114,7 @@ fun WriteCardScreen(
                         Text(
                             stringResource(
                                 R.string.write_card_required_card,
-                                cardDetails.name
+                                cardDetails?.name ?: ""
                             )
                         )
 

--- a/app/src/main/java/com/github/nacabaro/vbhelper/screens/scanScreen/screens/WriteCharacterScreen.kt
+++ b/app/src/main/java/com/github/nacabaro/vbhelper/screens/scanScreen/screens/WriteCharacterScreen.kt
@@ -45,16 +45,7 @@ fun WriteCharacterScreen(
     val application = LocalContext.current.applicationContext as VBHelper
     val database = application.container.db
     val scanRepository = ScanRepository(database)
-    val cardDetails by scanRepository.getCardDetails(characterId).collectAsState(Card(
-        id = 0,
-        cardId = 0,
-        name = "",
-        logo = byteArrayOf(),
-        logoHeight = 0,
-        logoWidth = 0,
-        stageCount = 0,
-        isBEm = false
-    ))
+    val cardDetails by scanRepository.getCardDetails(characterId).collectAsState(null)
 
     Scaffold(
         topBar = {
@@ -79,11 +70,11 @@ fun WriteCharacterScreen(
                 Row (
                     modifier = Modifier.padding(16.dp),
                 ){
-                    if (cardDetails.logoHeight > 0 && cardDetails.logoWidth > 0) {
+                    if (cardDetails != null && cardDetails!!.logoHeight > 0 && cardDetails!!.logoWidth > 0) {
                         val charaBitmapData = BitmapData(
-                            bitmap = cardDetails.logo,
-                            width = cardDetails.logoWidth,
-                            height = cardDetails.logoHeight
+                            bitmap = cardDetails!!.logo,
+                            width = cardDetails!!.logoWidth,
+                            height = cardDetails!!.logoHeight
                         )
                         val charaImageBitmapData = charaBitmapData.getImageBitmap(
                             context = LocalContext.current,

--- a/app/src/main/java/com/github/nacabaro/vbhelper/screens/scanScreen/screens/WritingScreen.kt
+++ b/app/src/main/java/com/github/nacabaro/vbhelper/screens/scanScreen/screens/WritingScreen.kt
@@ -8,17 +8,14 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.platform.LocalContext
 import com.github.cfogrady.vbnfc.data.NfcCharacter
 import com.github.nacabaro.vbhelper.ActivityLifecycleListener
-import com.github.nacabaro.vbhelper.di.VBHelper
 import com.github.nacabaro.vbhelper.screens.scanScreen.SCAN_SCREEN_ACTIVITY_LIFECYCLE_LISTENER
 import com.github.nacabaro.vbhelper.screens.scanScreen.ScanScreenController
-import com.github.nacabaro.vbhelper.source.StorageRepository
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import androidx.compose.ui.res.stringResource
 import com.github.nacabaro.vbhelper.R
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 @Composable
 fun WritingScreen(
@@ -30,14 +27,16 @@ fun WritingScreen(
 ) {
     val secrets by scanScreenController.secretsFlow.collectAsState(null)
 
-    val application = LocalContext.current.applicationContext as VBHelper
-    val storageRepository = StorageRepository(application.container.db)
-
     var writing by remember { mutableStateOf(false) }
     var writingScreen by remember { mutableStateOf(false) }
     var writingConfirmScreen by remember { mutableStateOf(false) }
     var isDoneSendingCard by remember { mutableStateOf(false) }
     var isDoneWritingCharacter by remember { mutableStateOf(false) }
+    // In an HCE transfer the whole character is sent and the local copy is deleted in the
+    // first step (onClickCheckCard). There is no physical "write character" step, so once the
+    // character no longer exists we must finish instead of advancing to WriteCharacterScreen
+    // (which would query the now-deleted character and crash).
+    var characterGone by remember { mutableStateOf(false) }
 
     DisposableEffect(writing) {
         if (writing) {
@@ -103,6 +102,9 @@ fun WritingScreen(
             scanScreenController.cancelRead()
             onCancel()
         }
+    } else if (characterGone) {
+        // HCE transfer finished in step 1; nothing to render, completion handled below.
+        writing = false
     } else if (!writingConfirmScreen) {
         writing = false
         WriteCharacterScreen (
@@ -126,13 +128,25 @@ fun WritingScreen(
 
     var completedWriting by remember { mutableStateOf(false) }
 
-    LaunchedEffect(isDoneSendingCard, isDoneWritingCharacter) {
-        withContext(Dispatchers.IO) {
-            if (isDoneSendingCard && isDoneWritingCharacter) {
-                storageRepository
-                    .deleteCharacter(characterId)
-                completedWriting = true
+    // Once the card has been sent, detect whether this was an HCE transfer: if the local
+    // character is already gone, the controller fully handled send + delete in step 1.
+    LaunchedEffect(isDoneSendingCard) {
+        if (isDoneSendingCard) {
+            val exists = withContext(Dispatchers.IO) {
+                scanScreenController.characterExists(characterId)
             }
+            characterGone = !exists
+        }
+    }
+
+    LaunchedEffect(isDoneSendingCard, isDoneWritingCharacter, characterGone) {
+        // Complete when either the physical two-step write is done, or the HCE transfer
+        // already removed the local character in step 1.
+        if ((isDoneSendingCard && isDoneWritingCharacter) || characterGone) {
+            // Deletion is owned by ScanScreenControllerImpl and only happens after a
+            // successful transfer (HCE: COMMIT acked by the watch in step 1; physical:
+            // write succeeded in step 2). This screen just advances the UI.
+            completedWriting = true
         }
     }
 

--- a/app/src/main/java/com/github/nacabaro/vbhelper/source/ScanRepository.kt
+++ b/app/src/main/java/com/github/nacabaro/vbhelper/source/ScanRepository.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.flow.Flow
 class ScanRepository(
     val database: AppDatabase
 ) {
-    fun getCardDetails(characterId: Long): Flow<Card> {
+    fun getCardDetails(characterId: Long): Flow<Card?> {
         return database.cardDao().getCardByCharacterId(characterId)
     }
 }

--- a/app/src/main/java/com/github/nacabaro/vbhelper/source/VitalWearCharacterExporter.kt
+++ b/app/src/main/java/com/github/nacabaro/vbhelper/source/VitalWearCharacterExporter.kt
@@ -21,12 +21,17 @@ class VitalWearCharacterExporter(
         val card = database.cardDao().getCardByCharacterIdSync(characterId)
             ?: error("Card not found for character $characterId")
         val cardProgress = database.cardProgressDao().getCardProgressSync(card.id) ?: 0
+        val transferDeviceType = when (userCharacter.characterType) {
+            DeviceType.BEDevice -> Character.CharacterStats.TransferDeviceType.TRANSFER_DEVICE_TYPE_BE
+            else -> Character.CharacterStats.TransferDeviceType.TRANSFER_DEVICE_TYPE_VB
+        }
         Character.newBuilder()
             .setCardId(card.cardId)
             .setCardName(card.name)
             .setCharacterStats(
                 Character.CharacterStats.newBuilder()
                     .setSlotId(database.userCharacterDao().getCharacterInfo(characterId).charaIndex)
+                    .setTransferDeviceType(transferDeviceType)
                     .setVitals(characterWithSprites.vitalPoints)
                     .setTrainingTimeRemainingInSeconds(resolveTrainingSeconds(characterId, userCharacter.characterType))
                     .setTimeUntilNextTransformation(characterWithSprites.transformationCountdown.toLong() * 60L)

--- a/app/src/main/java/com/github/nacabaro/vbhelper/source/VitalWearCharacterImporter.kt
+++ b/app/src/main/java/com/github/nacabaro/vbhelper/source/VitalWearCharacterImporter.kt
@@ -1,12 +1,15 @@
 package com.github.nacabaro.vbhelper.source
 
 import com.github.cfogrady.vbnfc.data.NfcCharacter
+import com.github.cfogrady.vbnfc.vb.SpecialMission
 import com.github.cfogrady.vitalwear.protos.Character
 import com.github.nacabaro.vbhelper.database.AppDatabase
 import com.github.nacabaro.vbhelper.domain.device_data.BECharacterData
+import com.github.nacabaro.vbhelper.domain.device_data.SpecialMissions
 import com.github.nacabaro.vbhelper.domain.device_data.UserCharacter
 import com.github.nacabaro.vbhelper.domain.device_data.VBCharacterData
 import com.github.nacabaro.vbhelper.utils.DeviceType
+import timber.log.Timber
 import kotlin.math.max
 
 class VitalWearCharacterImporter(
@@ -21,7 +24,7 @@ class VitalWearCharacterImporter(
         val importedCard = resolveCard(character)
             ?: return ImportResult(
                 success = false,
-                message = "Matching card not found in VBHelper. Import that card first."
+                message = "Card '${character.cardName}' (id ${character.cardId}) not found in VBHelper. Import that card first."
             )
 
         val slotId = character.characterStats.slotId
@@ -97,6 +100,22 @@ class VitalWearCharacterImporter(
                     totalTrophies = character.characterStats.trainedPp
                 )
             )
+            // VB characters need 4 special mission slots (one per type: steps, vitals,
+            // battles, wins). Physical bracelet imports get these from the NFC data, but
+            // HCE imports have no equivalent proto field, so we create them empty here.
+            val emptyMissions = (0..3).map { slot ->
+                SpecialMissions(
+                    characterId = userCharacterId,
+                    goal = 0,
+                    watchId = slot,
+                    progress = 0,
+                    status = SpecialMission.Status.UNAVAILABLE,
+                    timeElapsedInMinutes = 0,
+                    timeLimitInMinutes = 0,
+                    missionType = SpecialMission.Type.NONE
+                )
+            }
+            database.userCharacterDao().insertSpecialMissions(*emptyMissions.toTypedArray())
         }
 
         val now = System.currentTimeMillis()
@@ -152,17 +171,27 @@ class VitalWearCharacterImporter(
     private fun resolveCard(character: Character) = resolveCard(character.cardName, character.cardId)
 
     private fun resolveCard(cardName: String?, cardId: Int?): com.github.nacabaro.vbhelper.domain.card.Card? {
-        if (!cardName.isNullOrBlank()) {
-            database.cardDao().getCardByName(cardName)?.let { return it }
+        // 1. Exact (case-insensitive, trimmed) name match.
+        val trimmedName = cardName?.trim()
+        if (!trimmedName.isNullOrBlank()) {
+            database.cardDao().getCardByName(trimmedName)?.let { return it }
         }
 
+        // 2. Fall back to the DIM/card id (original behaviour: only a unique match).
         if (cardId != null) {
             val matches = database.cardDao().getCardByCardId(cardId)
             if (matches.size == 1) {
                 return matches.first()
             }
+            if (matches.size > 1) {
+                Timber.w("VitalWear import: cardId=$cardId matched ${matches.size} cards, not disambiguating")
+            }
         }
 
+        // Diagnostic: log exactly what the watch sent vs. what is stored locally.
+        val known = database.cardDao().getAllCards()
+            .joinToString { "${it.name}(cardId=${it.cardId})" }
+        Timber.w("VitalWear import: no card matched name='$cardName' cardId=$cardId. Known cards: $known")
         return null
     }
 

--- a/app/src/main/java/com/github/nacabaro/vbhelper/source/VitalWearCharacterImporter.kt
+++ b/app/src/main/java/com/github/nacabaro/vbhelper/source/VitalWearCharacterImporter.kt
@@ -5,6 +5,7 @@ import com.github.cfogrady.vitalwear.protos.Character
 import com.github.nacabaro.vbhelper.database.AppDatabase
 import com.github.nacabaro.vbhelper.domain.device_data.BECharacterData
 import com.github.nacabaro.vbhelper.domain.device_data.UserCharacter
+import com.github.nacabaro.vbhelper.domain.device_data.VBCharacterData
 import com.github.nacabaro.vbhelper.utils.DeviceType
 import kotlin.math.max
 
@@ -38,6 +39,8 @@ class VitalWearCharacterImporter(
         val currentPhaseBattles = character.characterStats.currentPhaseBattles
         val currentPhaseWins = character.characterStats.currentPhaseWins.coerceAtMost(currentPhaseBattles)
 
+        val deviceType = resolveDeviceType(character, importedCard)
+
         val userCharacterId = database.userCharacterDao().insertCharacterData(
             UserCharacter(
                 charId = cardCharacter.id,
@@ -53,38 +56,48 @@ class VitalWearCharacterImporter(
                 totalBattlesLost = (totalBattles - totalWins).coerceAtLeast(0),
                 activityLevel = 0,
                 heartRateCurrent = 0,
-                characterType = DeviceType.BEDevice,
+                characterType = deviceType,
                 isActive = true
             )
         )
 
-        database.userCharacterDao().insertBECharacterData(
-            BECharacterData(
-                id = userCharacterId,
-                trainingHp = character.characterStats.trainedHp,
-                trainingAp = character.characterStats.trainedAp,
-                trainingBp = character.characterStats.trainedBp,
-                remainingTrainingTimeInMinutes = secondsToMinutes(character.characterStats.trainingTimeRemainingInSeconds),
-                itemEffectMentalStateValue = 0,
-                itemEffectMentalStateMinutesRemaining = 0,
-                itemEffectActivityLevelValue = 0,
-                itemEffectActivityLevelMinutesRemaining = 0,
-                itemEffectVitalPointsChangeValue = 0,
-                itemEffectVitalPointsChangeMinutesRemaining = 0,
-                abilityRarity = resolveDefaultAbilityRarity(),
-                abilityType = 0,
-                abilityBranch = 0,
-                abilityReset = 0,
-                rank = 0,
-                itemType = 0,
-                itemMultiplier = 0,
-                itemRemainingTime = 0,
-                otp0 = "",
-                otp1 = "",
-                minorVersion = 0,
-                majorVersion = 0
+        if (deviceType == DeviceType.BEDevice) {
+            database.userCharacterDao().insertBECharacterData(
+                BECharacterData(
+                    id = userCharacterId,
+                    trainingHp = character.characterStats.trainedHp,
+                    trainingAp = character.characterStats.trainedAp,
+                    trainingBp = character.characterStats.trainedBp,
+                    remainingTrainingTimeInMinutes = secondsToMinutes(character.characterStats.trainingTimeRemainingInSeconds),
+                    itemEffectMentalStateValue = 0,
+                    itemEffectMentalStateMinutesRemaining = 0,
+                    itemEffectActivityLevelValue = 0,
+                    itemEffectActivityLevelMinutesRemaining = 0,
+                    itemEffectVitalPointsChangeValue = 0,
+                    itemEffectVitalPointsChangeMinutesRemaining = 0,
+                    abilityRarity = resolveDefaultAbilityRarity(),
+                    abilityType = 0,
+                    abilityBranch = 0,
+                    abilityReset = 0,
+                    rank = 0,
+                    itemType = 0,
+                    itemMultiplier = 0,
+                    itemRemainingTime = 0,
+                    otp0 = "",
+                    otp1 = "",
+                    minorVersion = 0,
+                    majorVersion = 0
+                )
             )
-        )
+        } else {
+            database.userCharacterDao().insertVBCharacterData(
+                VBCharacterData(
+                    id = userCharacterId,
+                    generation = 0,
+                    totalTrophies = character.characterStats.trainedPp
+                )
+            )
+        }
 
         val now = System.currentTimeMillis()
         database.dexDao().insertCharacter(slotId, importedCard.id, now)
@@ -116,6 +129,24 @@ class VitalWearCharacterImporter(
             success = true,
             message = "Imported ${importedCard.name} slot $slotId from VitalWear."
         )
+    }
+
+    /**
+     * Determines whether the imported VitalWear character is a VB DiM or a BE character.
+     *
+     * The VitalWear watch reports this via the proto's transferDeviceType field. Older
+     * exports leave it UNSPECIFIED, in which case we fall back to the matched card: BEm
+     * cards are always BE, everything else defaults to VB (the original Vital Bracelet).
+     */
+    private fun resolveDeviceType(
+        character: Character,
+        card: com.github.nacabaro.vbhelper.domain.card.Card
+    ): DeviceType {
+        return when (character.characterStats.transferDeviceType) {
+            Character.CharacterStats.TransferDeviceType.TRANSFER_DEVICE_TYPE_BE -> DeviceType.BEDevice
+            Character.CharacterStats.TransferDeviceType.TRANSFER_DEVICE_TYPE_VB -> DeviceType.VBDevice
+            else -> if (card.isBEm) DeviceType.BEDevice else DeviceType.VBDevice
+        }
     }
 
     private fun resolveCard(character: Character) = resolveCard(character.cardName, character.cardId)

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -56,7 +56,6 @@
     <string name="storage_character_image_description">キャラクター画像</string>
     <string name="storage_send_to_watch">デバイスへ転送</string>
     <string name="storage_send_to_vitalwear">VitalWearへ転送</string>
-    <string name="storage_send_to_vitalwear">VitalWearへ転送</string>
     <string name="storage_set_active">選択</string>
     <string name="storage_send_on_adventure">アドベンチャーへ出発</string>
     <string name="scan_no_nfc_on_device">NFC機能が見つかりません。</string>
@@ -146,7 +145,6 @@
     <string name="special_mission_steps_progress">歩数 %1$d 歩</string>
     <string name="special_mission_battles_progress">バトル %1$d 回</string>
     <string name="special_mission_wins_progress">勝利 %1$d 回</string>
-    <string name="settings_companion_import_card_image_title">カードのインポート</string>
     <string name="settings_companion_import_card_image_title">カードのインポート</string>
     <string name="companion_validation_connect_vb">デバイスに接続</string>
     <string name="companion_card_import_success">カードのインポートに成功しました。</string>


### PR DESCRIPTION
Fix: VitalWear characters imported with wrong device type (VB vs BE)

Problem:
When importing a character from the VitalWear watch via HCE, every character was being saved as a BE device, regardless of whether it was actually a VB DiM or a BE character. A VB DiM character like Agumon would be stored as BE.

Impact:

VB characters imported from the watch didn't show up when applying Special Mission items (the character picker only lists VB characters via getVBCharacters(), which filters by VBDevice).
Those characters were also rendered with the BE home screen instead of the VB one.
Root cause:
VitalWearCharacterImporter hardcoded characterType = DeviceType.BEDevice and always inserted BECharacterData for every imported character.

Fix:

The watch already reports the type in the proto's transferDeviceType field — the importer now reads it and sets the correct characterType.
VB characters now get VBCharacterData; BE characters get BECharacterData (as before).
When the field is UNSPECIFIED (older VitalWear exports), it falls back to the matched card: BEm cards → BE, everything else → VB (original Vital Bracelet).
Note:
This only affects new imports. Characters already saved with the wrong type need to be re-imported from the watch to be corrected (no migration included).