### PR TITLE
Fix double character deletion causing crash on HCE transfer to VitalWear

### DIFF
--- a/app/src/main/java/com/github/nacabaro/vbhelper/screens/scanScreen/ScanScreenControllerImpl.kt
+++ b/app/src/main/java/com/github/nacabaro/vbhelper/screens/scanScreen/ScanScreenControllerImpl.kt
@@ -231,9 +231,7 @@ class ScanScreenControllerImpl(
                     val proto = VitalWearCharacterExporter(componentActivity, database).buildCharacterProto(characterId)
                     val client = VitalWearHceReaderClient(isoDep)
                     client.sendCharacterToWatch(proto)
-                    database.userCharacterDao().deleteCharacterById(characterId)
-                    pendingExportCharacterId = null
-                    Log.i("NFC_WRITE", "Character sent to VitalWear and deleted from app (id=$characterId)")
+                    Log.i("NFC_WRITE", "Character sent to VitalWear (id=$characterId), deletion deferred to WritingScreen")
                     componentActivity.runOnUiThread {
                         Toast.makeText(componentActivity, componentActivity.getString(R.string.scan_sent_character_success), Toast.LENGTH_SHORT).show()
                     }


### PR DESCRIPTION
Character was deleted from the local DB both right after sendCharacterToWatch and again in WritingScreen's completion callback. The second deletion failed because the character no longer existed, causing the reported random crash when sending back to the watch. Deletion is now handled only once, in WritingScreen.