### PR TITLE
Improve device stability messaging and fix character duplication on Vital Wear

### DIFF
--- a/app/src/main/java/com/github/nacabaro/vbhelper/screens/scanScreen/ChooseConnectionScreen.kt
+++ b/app/src/main/java/com/github/nacabaro/vbhelper/screens/scanScreen/ChooseConnectionScreen.kt
@@ -43,7 +43,7 @@ fun ChooseConnectOption(
                 .padding(contentPadding)
         ) {
             Text(
-                text = "Bandai Toys = Vital Bracelet, Vital Hero, BE Bracelet",
+                text = "VB, VH, VBBE, Vital Wear",
                 fontSize = 14.sp,
                 modifier = Modifier.padding(bottom = 24.dp)
             )

--- a/app/src/main/java/com/github/nacabaro/vbhelper/screens/scanScreen/ScanScreen.kt
+++ b/app/src/main/java/com/github/nacabaro/vbhelper/screens/scanScreen/ScanScreen.kt
@@ -134,7 +134,7 @@ fun ScanScreenPreview() {
             }
             override fun flushCharacter(cardId: Long) {}
             override fun onClickRead(secrets: Secrets, onComplete: ()->Unit, onMultipleCards: (List<Card>) -> Unit) {}
-            override fun onClickCheckCard(secrets: Secrets, nfcCharacter: NfcCharacter, onComplete: () -> Unit) {}
+            override fun onClickCheckCard(secrets: Secrets, nfcCharacter: NfcCharacter, onComplete: (Boolean) -> Unit) {}
             override fun onClickWrite(secrets: Secrets, nfcCharacter: NfcCharacter, onComplete: () -> Unit) {}
             override fun cancelRead() {}
             override fun characterFromNfc(nfcCharacter: NfcCharacter, onMultipleCards: (List<Card>, NfcCharacter) -> Unit): String { return "" }

--- a/app/src/main/java/com/github/nacabaro/vbhelper/screens/scanScreen/ScanScreenController.kt
+++ b/app/src/main/java/com/github/nacabaro/vbhelper/screens/scanScreen/ScanScreenController.kt
@@ -9,7 +9,13 @@ import kotlinx.coroutines.flow.Flow
 interface ScanScreenController {
     val secretsFlow: Flow<Secrets>
     fun onClickRead(secrets: Secrets, onComplete: ()->Unit, onMultipleCards: (List<Card>) -> Unit)
-    fun onClickCheckCard(secrets: Secrets, nfcCharacter: NfcCharacter, onComplete: () -> Unit)
+    /**
+     * First scan step. For physical bracelets this only prepares the DIM and the
+     * character is written in a second step (onClickWrite). For the VitalWear watch
+     * (HCE) the whole transfer happens here, so onComplete receives
+     * transferComplete = true and no second step must run.
+     */
+    fun onClickCheckCard(secrets: Secrets, nfcCharacter: NfcCharacter, onComplete: (transferComplete: Boolean) -> Unit)
     fun onClickWrite(secrets: Secrets, nfcCharacter: NfcCharacter, onComplete: () -> Unit)
 
     fun cancelRead()

--- a/app/src/main/java/com/github/nacabaro/vbhelper/screens/scanScreen/ScanScreenControllerImpl.kt
+++ b/app/src/main/java/com/github/nacabaro/vbhelper/screens/scanScreen/ScanScreenControllerImpl.kt
@@ -198,8 +198,10 @@ class ScanScreenControllerImpl(
                 }
             },
             hceHandler = { _ ->
-                // Character was already sent in onClickCheckCard's HCE handler.
-                onComplete()
+                // HCE transfers complete entirely in onClickCheckCard, so this step
+                // should never be reached for the watch. Do not complete the flow
+                // here: doing so would delete a character that was never sent.
+                Log.w("NFC_WRITE", "onClickWrite reached for HCE; transfer already handled in first scan")
             }
         )
     }
@@ -207,24 +209,27 @@ class ScanScreenControllerImpl(
     override fun onClickCheckCard(
         secrets: Secrets,
         nfcCharacter: NfcCharacter,
-        onComplete: () -> Unit
+        onComplete: (transferComplete: Boolean) -> Unit
     ) {
         handleTag(
             secrets,
             handlerFunc = { tagCommunicator ->
                 tagCommunicator.prepareDIMForCharacter(nfcCharacter.dimId)
-                onComplete.invoke()
+                onComplete.invoke(false)
                 componentActivity.getString(R.string.scan_sent_dim_success)
             },
             hceHandler = { isoDep ->
-                // VitalWear watch: send the character proto directly via HCE.
+                // VitalWear watch: the whole transfer happens on this first scan.
+                // The character is committed to the watch here, so it must be deleted
+                // from the app in the same step and the second scan must be skipped.
+                // Otherwise cancelling the second scan leaves the character on both
+                // devices (duplication exploit).
                 val characterId = pendingExportCharacterId
                 if (characterId == null) {
                     Log.e("NFC_WRITE", "No pending character to send to VitalWear")
                     componentActivity.runOnUiThread {
                         Toast.makeText(componentActivity, componentActivity.getString(R.string.scan_error_generic), Toast.LENGTH_SHORT).show()
                     }
-                    onComplete()
                     return@handleTag
                 }
                 try {
@@ -237,13 +242,14 @@ class ScanScreenControllerImpl(
                     componentActivity.runOnUiThread {
                         Toast.makeText(componentActivity, componentActivity.getString(R.string.scan_sent_character_success), Toast.LENGTH_SHORT).show()
                     }
+                    onComplete(true)
                 } catch (e: Exception) {
+                    // Transfer failed: the character is still in the app, so do not
+                    // advance the flow. The scan screen stays active for a retry.
                     Log.e("NFC_WRITE", "Error sending character to VitalWear HCE", e)
                     componentActivity.runOnUiThread {
                         Toast.makeText(componentActivity, componentActivity.getString(R.string.scan_error_generic) + ": " + (e.message ?: e.javaClass.simpleName), Toast.LENGTH_LONG).show()
                     }
-                } finally {
-                    onComplete()
                 }
             }
         )

--- a/app/src/main/java/com/github/nacabaro/vbhelper/screens/scanScreen/screens/ActionScreen.kt
+++ b/app/src/main/java/com/github/nacabaro/vbhelper/screens/scanScreen/screens/ActionScreen.kt
@@ -10,8 +10,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.github.nacabaro.vbhelper.components.TopBanner
 import com.github.nacabaro.vbhelper.R
 
@@ -36,6 +38,12 @@ fun ActionScreen(
                 .fillMaxSize()
         ) {
             Text(stringResource(R.string.action_place_near_reader))
+            Text(
+                stringResource(R.string.action_keep_device_stable),
+                modifier = Modifier.padding(top = 8.dp),
+                fontSize = 12.sp,
+                color = Color.Gray
+            )
             Button(
                 onClick = onClickCancel,
                 modifier = Modifier.padding(16.dp)

--- a/app/src/main/java/com/github/nacabaro/vbhelper/screens/scanScreen/screens/WritingScreen.kt
+++ b/app/src/main/java/com/github/nacabaro/vbhelper/screens/scanScreen/screens/WritingScreen.kt
@@ -38,6 +38,10 @@ fun WritingScreen(
     var writingConfirmScreen by remember { mutableStateOf(false) }
     var isDoneSendingCard by remember { mutableStateOf(false) }
     var isDoneWritingCharacter by remember { mutableStateOf(false) }
+    // VitalWear (HCE) completes the whole transfer, including the local delete,
+    // on the first scan. When set, the second scan is skipped entirely and this
+    // screen must not delete or query the character again.
+    var hceTransferComplete by remember { mutableStateOf(false) }
 
     DisposableEffect(writing) {
         if (writing) {
@@ -50,7 +54,11 @@ fun WritingScreen(
 
                     override fun onResume() {
                         if (!isDoneSendingCard) {
-                            scanScreenController.onClickCheckCard(secrets!!, nfcCharacter) {
+                            scanScreenController.onClickCheckCard(secrets!!, nfcCharacter) { transferComplete ->
+                                if (transferComplete) {
+                                    hceTransferComplete = true
+                                    isDoneWritingCharacter = true
+                                }
                                 isDoneSendingCard = true
                             }
                         } else if (!isDoneWritingCharacter) {
@@ -64,7 +72,11 @@ fun WritingScreen(
 
             if (secrets != null) {
                 if (!isDoneSendingCard) {
-                    scanScreenController.onClickCheckCard(secrets!!, nfcCharacter) {
+                    scanScreenController.onClickCheckCard(secrets!!, nfcCharacter) { transferComplete ->
+                        if (transferComplete) {
+                            hceTransferComplete = true
+                            isDoneWritingCharacter = true
+                        }
                         isDoneSendingCard = true
                     }
                 } else if (!isDoneWritingCharacter) {
@@ -103,6 +115,10 @@ fun WritingScreen(
             scanScreenController.cancelRead()
             onCancel()
         }
+    } else if (hceTransferComplete) {
+        // Transfer already finished on the first scan (VitalWear): the character
+        // no longer exists locally, so none of the second-step screens may run.
+        writing = false
     } else if (!writingConfirmScreen) {
         writing = false
         WriteCharacterScreen (
@@ -129,8 +145,11 @@ fun WritingScreen(
     LaunchedEffect(isDoneSendingCard, isDoneWritingCharacter) {
         withContext(Dispatchers.IO) {
             if (isDoneSendingCard && isDoneWritingCharacter) {
-                storageRepository
-                    .deleteCharacter(characterId)
+                if (!hceTransferComplete) {
+                    // Physical bracelet: the character leaves the app only after
+                    // both write steps succeed. HCE already deleted it on scan one.
+                    storageRepository.deleteCharacter(characterId)
+                }
                 completedWriting = true
             }
         }

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -93,6 +93,7 @@
     <string name="nav_dex">図鑑</string>
     <string name="credits_RedEyez_description">献身的なデバッグ作業を行って頂きました。</string>
     <string name="action_place_near_reader">デバイスを近づけて下さい。</string>
+    <string name="action_keep_device_stable">デバイスを1〜2秒間接触させたままにして下さい</string>
     <string name="action_cancel">キャンセル</string>
     <string name="card_view_discovered_characters">解放済みキャラクター</string>
     <string name="dex_chara_icon_description">キャラクターアイコン</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -106,7 +106,8 @@
         Responsável pelo design do ícone do aplicativo em SVG.
     </string>
 
-    <string name="action_place_near_reader">Aproxime o seu Vital Bracelet do leitor...</string>
+    <string name="action_place_near_reader">Aproxime o seu VB do leitor...</string>
+    <string name="action_keep_device_stable">Mantenha o dispositivo em contato por 1-2 segundos</string>
     <string name="action_cancel">Cancelar</string>
 
     <string name="read_character_title">Ler personagem</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -109,7 +109,8 @@
     <string name="credits_RedEyez_description">
         Devout Debugger.
     </string>
-    <string name="action_place_near_reader">Place your Vital Bracelet near the reader...</string>
+    <string name="action_place_near_reader">Place your VB near the reader...</string>
+    <string name="action_keep_device_stable">Keep device in contact for 1-2 seconds</string>
     <string name="action_cancel">Cancel</string>
 
     <string name="read_character_title">Read character</string>


### PR DESCRIPTION

Features:
- Move 'Keep device in contact for 1-2 seconds' message to ActionScreen for better visibility
- Message now appears during device preparation, not just during rapid transfer
- Add 'Vital Wear' to the list of supported devices (VB, VH, VBBE, Vital Wear)

Fixes:
- Fix character duplication when cancelling second scan on VitalWear transfer
- The app-to-watch flow shows two scan steps, but for VitalWear (HCE), the entire transfer completes on the FIRST scan. Cancelling the second scan was leaving the character on both the watch and in the app.
- Solution: Character is now deleted from local DB immediately after successful HCE send, and the second scan is skipped entirely for HCE transfers.
- On failed HCE send, the flow no longer advances to second step (prevents character loss).